### PR TITLE
fix: the password field is now red when password has incorrect format

### DIFF
--- a/app/src/main/java/com/example/recipekeeper/ui/screens/auth/AuthTextFields.kt
+++ b/app/src/main/java/com/example/recipekeeper/ui/screens/auth/AuthTextFields.kt
@@ -27,7 +27,7 @@ fun PasswordTextField(
     label: String,
     password: String,
     passwordError: Boolean,
-    passwordErrorMessage: String,
+    passwordErrorMessage: String?,
     onPasswordChanged: (String) -> Unit,
     keyboardOptions: KeyboardOptions,
     modifier: Modifier = Modifier,
@@ -43,13 +43,12 @@ fun PasswordTextField(
         singleLine = true,
         shape = MaterialTheme.shapes.medium,
         isError = passwordError,
-        supportingText = if (passwordError) {
-            if(password.isBlank()) {
-                { Text(stringResource(R.string.required_field)) }
-            } else {
-                { Text(passwordErrorMessage) }
-            }
-        } else null,
+        supportingText = when {
+            !passwordError -> null
+            password.isBlank() -> { { Text(stringResource(R.string.required_field)) } }
+            passwordErrorMessage != null -> { { Text(passwordErrorMessage) } }
+            else -> null
+        },
         visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation(),
         trailingIcon = {
             IconButton(onClick = { passwordVisible = !passwordVisible }) {

--- a/app/src/main/java/com/example/recipekeeper/ui/screens/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/recipekeeper/ui/screens/auth/login/LoginScreen.kt
@@ -64,7 +64,7 @@ fun LoginScreen(
         LoginLayout(
             email = uiState.email,
             password = uiState.password,
-            passwordError = false,
+            passwordError = uiState.passwordError,
             emailError = uiState.emailError,
             onEmailChanged = {
                 loginViewModel.updateEmail(it)
@@ -125,7 +125,7 @@ fun LoginLayout(
                 onDone = { onLogin() }
             ),
             passwordError = passwordError,
-            passwordErrorMessage = "",
+            passwordErrorMessage = null,
             modifier = Modifier.fillMaxWidth()
         )
         Spacer(modifier = Modifier.size(dimensionResource(R.dimen.padding_small)))


### PR DESCRIPTION
Closes #19 
Sur la page de login, le champ du mot de passe affiche maintenant un message "Champ requis" lorsque le champ est vide.
Le textfield devient rouge s'il y a une erreur sur le champ.