### PR TITLE
fix: dynamic screen name in the topbar

### DIFF
--- a/app/src/main/java/com/example/recipekeeper/RecipeKeeperApp.kt
+++ b/app/src/main/java/com/example/recipekeeper/RecipeKeeperApp.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavType
 import androidx.navigation.navArgument
@@ -84,6 +85,17 @@ fun RecipeKeeperApp(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
+    val currentFolderName = backStackEntry?.arguments?.getString("folderName")
+
+    val  topBarTitle = if (currentFolderName != null) {
+        currentFolderName
+    } else {
+        val currentScreen = try {
+            RecipeKeeperScreen.valueOf(currentRoute?.substringBefore('?') ?: RecipeKeeperScreen.Home.name)
+        } catch (e: Exception) { RecipeKeeperScreen.Home }
+        stringResource(currentScreen.title)
+    }
+
     LaunchedEffect(currentRoute) {
         recipeKeeperViewModel.onNavigationChange(currentRoute)
     }
@@ -128,7 +140,7 @@ fun RecipeKeeperApp(
         topBar = {
             if (uiState.isTopBarVisible) {
                 RecipeKeeperTopBar(
-                    currentScreen = uiState.currentScreen,
+                    title = topBarTitle,
                     canNavigateBack = navController.previousBackStackEntry != null,
                     navigateUp = { navController.navigateUp() }
                 )
@@ -159,20 +171,26 @@ fun RecipeKeeperApp(
                 .fillMaxSize()
         ) {
             composable(
-                route = "${RecipeKeeperScreen.Home.name}?folderId={folderId}",
-                arguments = listOf(navArgument("folderId") {
+                route = "${RecipeKeeperScreen.Home.name}?folderId={folderId}&folderName={folderName}",
+                arguments = listOf(
+                    navArgument("folderId") {
                     type = NavType.StringType
                     nullable = true
                     defaultValue = null
-                })
+                },
+                    navArgument("folderName") {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                    })
             ) {
                 entry ->
                 if (homeViewModelFactory != null) {
                     val folderId = entry.arguments?.getString("folderId")
                     HomeScreen(
                         folderId = folderId,
-                        onNavigateToSubFolder = { subFolderId ->
-                            navController.navigate("${RecipeKeeperScreen.Home.name}?folderId=$subFolderId")                     },
+                        onNavigateToSubFolder = { subFolderId, subFolderName ->
+                            navController.navigate("${RecipeKeeperScreen.Home.name}?folderId=$subFolderId&folderName=$subFolderName")                     },
                         onNavigateToRecipeDetails = {},
                         homeFactory = homeViewModelFactory,
                         modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/example/recipekeeper/RecipeKeeperApp.kt
+++ b/app/src/main/java/com/example/recipekeeper/RecipeKeeperApp.kt
@@ -87,7 +87,7 @@ fun RecipeKeeperApp(
 
     val currentFolderName = backStackEntry?.arguments?.getString("folderName")
 
-    val  topBarTitle = if (currentFolderName != null) {
+    val topBarTitle = if (currentFolderName != null) {
         currentFolderName
     } else {
         val currentScreen = try {

--- a/app/src/main/java/com/example/recipekeeper/ui/components/RecipeKeeperTopBar.kt
+++ b/app/src/main/java/com/example/recipekeeper/ui/components/RecipeKeeperTopBar.kt
@@ -16,13 +16,13 @@ import com.example.recipekeeper.ui.models.RecipeKeeperScreen
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun RecipeKeeperTopBar(
-    currentScreen: RecipeKeeperScreen,
+    title: String,
     canNavigateBack: Boolean,
     navigateUp: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     TopAppBar(
-        title = { Text(stringResource(currentScreen.title)) },
+        title = { Text(title) },
         modifier = modifier,
         navigationIcon = {
             if (canNavigateBack) {

--- a/app/src/main/java/com/example/recipekeeper/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/recipekeeper/ui/screens/home/HomeScreen.kt
@@ -27,8 +27,7 @@ fun HomeScreen(
     onNavigateToRecipeDetails: (String) -> Unit,
     homeFactory: HomeViewModelFactory,
     modifier: Modifier = Modifier,
-    folderId: String? = null,
-    folderName: String? = null
+    folderId: String? = null
 ) {
     val homeViewModel: HomeViewModel = viewModel(factory = homeFactory)
     val uiState by homeViewModel.uiState.collectAsState()

--- a/app/src/main/java/com/example/recipekeeper/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/recipekeeper/ui/screens/home/HomeScreen.kt
@@ -23,11 +23,12 @@ import com.example.recipekeeper.ui.components.SectionTitle
 
 @Composable
 fun HomeScreen(
-    onNavigateToSubFolder: (String) -> Unit,
+    onNavigateToSubFolder: (String, String) -> Unit,
     onNavigateToRecipeDetails: (String) -> Unit,
     homeFactory: HomeViewModelFactory,
     modifier: Modifier = Modifier,
-    folderId: String? = null
+    folderId: String? = null,
+    folderName: String? = null
 ) {
     val homeViewModel: HomeViewModel = viewModel(factory = homeFactory)
     val uiState by homeViewModel.uiState.collectAsState()
@@ -55,7 +56,7 @@ fun HomeScreen(
                     title = folder.name,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .clickable { onNavigateToSubFolder(folder.id) }
+                        .clickable { onNavigateToSubFolder(folder.id, folder.name) }
                 )
             }
         }


### PR DESCRIPTION
Closes #20 

Le nom dans la topbar est désormais dynamique et peut être changé en fonction des besoins 